### PR TITLE
rerender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/xmltodict-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/xmltodict-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/xmltodict-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/xmltodict-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/xmltodict-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/xmltodict-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/xmltodict-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/xmltodict-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/xmltodict/
 Updating xmltodict-feedstock
 ============================
 
-If you would like to improve the xmltodict recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the xmltodict recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/xmltodict-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase


### PR DESCRIPTION
@synapticarbors somehow only `PY35` binaries made into the channel for `OS X`. Let's see if forcing a new build, via rerender, fixes this.