### PR TITLE
[ci skip] Inline package name

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,15 +1,14 @@
 schema_version: 1
 
 context:
-  name: xmltodict
   version: "1.0.4"
 
 package:
-  name: ${{ name|lower }}
+  name: xmltodict
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/xmltodict-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/x/xmltodict/xmltodict-${{ version }}.tar.gz
   sha256: 6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61
 
 build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Inline the package name per the discussion
in conda-forge/conda-forge.github.io#2712.  While it is not really necessary to proactively change existing packages, xmltodict is a good candidate for use in conda-forge tutorials, so we'd really love it to follow the best practices.

Skipping CI since there is no point in rebuilding the packages, given nothing really changes.

xref conda-forge/conda-forge.github.io#2765

